### PR TITLE
Update browser and os version for chrome in browserstack

### DIFF
--- a/lib/browsenator/remote/browserstack/desktop/chrome.rb
+++ b/lib/browsenator/remote/browserstack/desktop/chrome.rb
@@ -10,9 +10,9 @@ module Browsenator
           def initialize(opts = {})
             @caps = Selenium::WebDriver::Remote::Capabilities.new
             @caps['browser'] = 'Chrome'
-            @caps['browser_version'] = opts[:browser_version] || '66.0'
+            @caps['browser_version'] = opts[:browser_version] || '70.0'
             @caps['os'] = 'OS X'
-            @caps['os_version'] = 'High Sierra'
+            @caps['os_version'] = 'Mojave'
             @caps['resolution'] = screen_resolution(opts[:screen_width], opts[:screen_height])
             @caps['project'] = opts[:project]
             @caps['browserstack.local'] = opts[:local_testing].to_s

--- a/spec/browsenator/remote/browserstack/desktop/chrome_spec.rb
+++ b/spec/browsenator/remote/browserstack/desktop/chrome_spec.rb
@@ -4,7 +4,7 @@ describe Browsenator::Remote::Browserstack::Desktop::Chrome do
       @browser.quit
     end
 
-    it 'starts Chrome version 66 in a Mac when no version is specified' do
+    it 'starts Chrome version 70 in a Mac when no version is specified' do
       @browser = described_class.new(project: 'Test').open
       browser_type = @browser.driver.capabilities.browser_name
       browser_version = @browser.driver.capabilities.version
@@ -13,7 +13,7 @@ describe Browsenator::Remote::Browserstack::Desktop::Chrome do
       expect(@browser).to be_a(Watir::Browser)
       expect(@browser.driver).to be_a(Selenium::WebDriver::Remote::Driver)
       expect(browser_type).to eql('chrome')
-      expect(browser_version).to match(/^66/)
+      expect(browser_version).to match(/^70/)
       expect(operating_system).to match(/mac/)
     end
 


### PR DESCRIPTION
## Summary
Update browser and os version for chrome in browserstack for chrome remote:
- Chrome 70.0
- Mac OS X Mojave

