### PR TITLE
Add Google Pixel with android 8 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For starting a remote browser in a mobile device, you only need to specify the d
 Browsenator.for(:samsung_galaxy_s8, remote: :browserstack)
 ```
 
-You can start the following remote **real** mobile browsers: `:samsung_galaxy_s8`, `:iphone8`.
+You can start the following remote **real** mobile browsers: `:samsung_galaxy_s8`, `:google_pixel`, `:iphone8`.
 
 ##### Device orientation
 
@@ -176,6 +176,7 @@ Browsenator.for(:samsung_galaxy_s8, remote: :browserstack, device_orientation: '
 
 - Orientation: Portrait
 - Samsung Galaxy S8: Android 7.0
+- Google Pixel: Android 8.0
 - iPhone 8: iOS 11.0
 
 ##### Other configurations

--- a/browsenator.gemspec
+++ b/browsenator.gemspec
@@ -1,4 +1,3 @@
-
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 

--- a/lib/browsenator/remote/browserstack.rb
+++ b/lib/browsenator/remote/browserstack.rb
@@ -4,6 +4,7 @@ require_relative 'browserstack/desktop/safari'
 require_relative 'browserstack/desktop/edge'
 require_relative 'browserstack/desktop/ie'
 require_relative 'browserstack/mobile/samsung_galaxy_s8'
+require_relative 'browserstack/mobile/google_pixel'
 require_relative 'browserstack/mobile/iphone8'
 
 module Browsenator
@@ -14,6 +15,7 @@ module Browsenator
       class << self
         def for(platform, opts = {})
           return platform_class[platform].new(opts).open if platform_class.key?(platform)
+
           raise ArgumentError, "Unknown Browserstack platform: #{platform.inspect}"
         end
 
@@ -26,6 +28,7 @@ module Browsenator
             edge: Desktop::Edge,
             ie: Desktop::IE,
             samsung_galaxy_s8: Mobile::SamsungGalaxyS8,
+            google_pixel: Mobile::GooglePixel,
             iphone8: Mobile::Iphone8
           }
         end

--- a/lib/browsenator/remote/browserstack/mobile/google_pixel.rb
+++ b/lib/browsenator/remote/browserstack/mobile/google_pixel.rb
@@ -1,0 +1,22 @@
+module Browsenator
+  module Remote
+    class Browserstack
+      class Mobile
+        class GooglePixel < Browserstack
+          def initialize(opts = {})
+            @caps = Selenium::WebDriver::Remote::Capabilities.new
+            @caps['os_version'] = '8.0'
+            @caps['device'] = 'Google Pixel'
+            @caps['real_mobile'] = 'true'
+            @caps['deviceOrientation'] = opts[:device_orientation] || 'portrait'
+            @caps['javascriptEnabled'] = 'true'
+            @caps['project'] = opts[:project]
+            @caps['browserstack.appium_version'] = '1.9.1'
+            @caps['browserstack.local'] = (opts[:local_testing] || 'false').to_s
+            @caps['browserstack.localIdentifier'] = opts[:local_identifier]
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/browsenator/remote/browserstack/mobile/google_pixel_spec.rb
+++ b/spec/browsenator/remote/browserstack/mobile/google_pixel_spec.rb
@@ -1,0 +1,18 @@
+describe Browsenator::Remote::Browserstack::Mobile::GooglePixel do
+  describe '#open' do
+    after(:each) do
+      @browser.quit
+    end
+
+    it 'starts Chrome in a linux device' do
+      @browser = described_class.new(project: 'Test').open
+      browser_type = @browser.driver.capabilities.browser_name
+      operating_system = @browser.driver.capabilities.platform
+
+      expect(@browser).to be_a(Watir::Browser)
+      expect(@browser.driver).to be_a(Selenium::WebDriver::Remote::Driver)
+      expect(browser_type).to eql('chrome')
+      expect(operating_system).to match('linux')
+    end
+  end
+end

--- a/spec/browsenator/remote/browserstack_spec.rb
+++ b/spec/browsenator/remote/browserstack_spec.rb
@@ -85,6 +85,23 @@ describe Browsenator::Remote::Browserstack do
       described_class.for(:samsung_galaxy_s8, opts)
     end
 
+    it 'starts Chrome in mobile when platform is :google_pixel' do
+      chrome = double(:chrome)
+      expect(Browsenator::Remote::Browserstack::Mobile::GooglePixel).to receive(:new).with({}).and_return(chrome)
+      expect(chrome).to receive(:open)
+
+      described_class.for(:google_pixel)
+    end
+
+    it 'starts Chrome in mobile when platform is :google_pixel and passing options' do
+      chrome = double(:chrome)
+      opts = { project: 'Test' }
+      expect(Browsenator::Remote::Browserstack::Mobile::GooglePixel).to receive(:new).with(opts).and_return(chrome)
+      expect(chrome).to receive(:open)
+
+      described_class.for(:google_pixel, opts)
+    end
+
     it 'starts Safari in mobile when platform is :iphone8' do
       safari = double(:safari)
       expect(Browsenator::Remote::Browserstack::Mobile::Iphone8).to receive(:new).with({}).and_return(safari)


### PR DESCRIPTION
## Summary
Add support for Google Pixel in browserstack:

Android 8.0
Appium 1.9.1
Mac OS X
## Checklist

* [x] Feature branch is up-to-date with `master` (if not - rebase it).
* [x] I've added tests for my code.
* [x] I've updated the README.
* [x] The PR relates to *only* one subject with a clear title and description.
* [x] Tests and RuboCop have been successfully executed.
* [ ] Update CHANGELOG if relevant.
